### PR TITLE
Remove "vicuña"

### DIFF
--- a/words.json
+++ b/words.json
@@ -216,7 +216,6 @@
   "trout",
   "turkey",
   "turtle",
-  "vicuña",
   "viper",
   "vulture",
   "wallaby",


### PR DESCRIPTION
Remove "vicuña" due to incompatibility issues with special characters in some environments